### PR TITLE
Simplified ServiceCode, updated Base URL

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -17,7 +17,7 @@ ICON_MOVIES = "icon-movies.png"
 ICON_AZ = "icon-az.png"
 ICON_GENRE = "icon-genre.png"
 ICON_QUEUE = "icon-queue.png"
-BASE_URL = "http://www.animetoon.tv"
+BASE_URL = "http://www.animetoon.org"
 
 ######################################################################################
 # Set global variables
@@ -33,7 +33,7 @@ def Start():
 	VideoClipObject.thumb = R(ICON_COVER)
 	VideoClipObject.art = R(ART)
 	HTTP.CacheTime = CACHE_1HOUR
-	
+
 ######################################################################################
 # Menu hierarchy. page_count is used for pagination and should always start at 0.
 
@@ -47,7 +47,7 @@ def MainMenu():
 	oc.add(DirectoryObject(key = Callback(MoviesMenu, title="Movies"), title = "Movies", thumb = R(ICON_MOVIES)))
 	oc.add(DirectoryObject(key = Callback(Bookmarks, title="Bookmarks"), title = "Bookmarks", thumb = R(ICON_QUEUE)))
 	oc.add(InputDirectoryObject(key=Callback(Search), title = "Search", prompt = "Search for shows?", thumb = R(ICON_SEARCH)))
-	
+
 	return oc
 
 @route(PREFIX + "/animemenu")
@@ -60,9 +60,9 @@ def AnimeMenu(title):
 	oc.add(DirectoryObject(key = Callback(ShowCategory, title="Ongoing Series", category = "/ongoing-dubbed-anime/", page_count = 0, is_popular = 0), title = "Ongoing Series", thumb = R(ICON_SERIES)))
 	oc.add(DirectoryObject(key = Callback(AZMenu, title="Browse A-Z", category ="/dubbed-anime/"), title = "Browse A-Z", thumb = R(ICON_AZ)))
 	oc.add(DirectoryObject(key = Callback(GenreMenu, title="Browse Genres", category="/dubbed-anime-genres/"), title = "Browse Genres", thumb = R(ICON_GENRE)))
-	
+
 	return oc
-	
+
 @route(PREFIX + "/cartoonmenu")
 def CartoonMenu(title):
 
@@ -73,11 +73,11 @@ def CartoonMenu(title):
 	oc.add(DirectoryObject(key = Callback(ShowCategory, title="Ongoing Series", category = "/ongoing-cartoon/", page_count = 0, is_popular = 0), title = "Ongoing Series", thumb = R(ICON_SERIES)))
 	oc.add(DirectoryObject(key = Callback(AZMenu, title="Browse A-Z", category ="/cartoon/"), title = "Browse A-Z", thumb = R(ICON_AZ)))
 	oc.add(DirectoryObject(key = Callback(GenreMenu, title="Browse Genres", category="/cartoon-genres/"), title = "Browse Genres", thumb = R(ICON_GENRE)))
-	
+
 	return oc
 
 
-@route(PREFIX + "/moviesmenu")	
+@route(PREFIX + "/moviesmenu")
 def MoviesMenu(title):
 
 	oc = ObjectContainer(title1 = title)
@@ -86,7 +86,7 @@ def MoviesMenu(title):
 	oc.add(DirectoryObject(key = Callback(ShowCategory, title="Recently Added", category = "/recent-movies/", page_count = 0, is_popular = 0), title = "Recently Added", thumb = R(ICON_MOVIES)))
 	oc.add(DirectoryObject(key = Callback(AZMenu, title="Browse A-Z", category ="/movies/"), title = "Browse A-Z", thumb = R(ICON_AZ)))
 	oc.add(DirectoryObject(key = Callback(GenreMenu, title="Browse Genres", category="/movie-genres/"), title = "Browse Genres", thumb = R(ICON_GENRE)))
-	
+
 	return oc
 
 @route(PREFIX + "/azmenu")
@@ -94,12 +94,12 @@ def AZMenu(title, category):
 
 	oc = ObjectContainer(title1 = title)
 	page_data = HTML.ElementFromURL(BASE_URL + category)
-	
+
 	for each in page_data.xpath("//div[@id='options_bar']/ul/li/a")[6:32]:
 		page_title = each.xpath("./text()")[0]
 		page_url = each.xpath("./@href")[0].split(BASE_URL)[1] + "/"
 		oc.add(DirectoryObject(key = Callback(ShowCategory, title = page_title, category = page_url, page_count = 0, is_popular = 0), title = page_title, thumb = R(ICON_LIST)))
-		
+
 	return oc
 
 @route(PREFIX + "/genremenu")
@@ -107,24 +107,24 @@ def GenreMenu(title, category):
 
 	oc = ObjectContainer(title1 = title)
 	page_data = HTML.ElementFromURL(BASE_URL + category)
-	
+
 	for each in page_data.xpath("//table[@id='listing']//a"):
 		page_title = each.xpath("./text()")[0]
 		page_url = each.xpath("./@href")[0].split(BASE_URL)[1] + "/"
 		oc.add(DirectoryObject(key = Callback(ShowCategory, title = page_title, category = page_url, page_count = 0, is_popular = 0), title = page_title, thumb = R(ICON_LIST)))
-		
-	return oc	
+
+	return oc
 
 ######################################################################################
 # Loads bookmarked shows from Dict.  Titles are used as keys to store the show urls.
 
-@route(PREFIX + "/bookmarks")	
+@route(PREFIX + "/bookmarks")
 def Bookmarks(title):
 
 	oc = ObjectContainer(title1 = title)
-	
+
 	if len(Dict) < 1:
-		return ObjectContainer(header="Bookmarks", message="Your bookmarks list is empty! You can add bookmarks while browsing shows.") 
+		return ObjectContainer(header="Bookmarks", message="Your bookmarks list is empty! You can add bookmarks while browsing shows.")
 
 	for each in Dict:
 		show_url = Dict[each]
@@ -138,7 +138,7 @@ def Bookmarks(title):
 				show_summary = page_data.xpath("//div[@id='series_details']/div[2]/div/text()")[0].strip()
 			except:
 				show_summary = page_data.xpath("//div[@id='series_details']/div/div/text()")[0].strip()
-			
+
 		oc.add(DirectoryObject(
 			key = Callback(PageEpisodes, show_title = show_title, show_url = show_url),
 			title = show_title,
@@ -146,7 +146,7 @@ def Bookmarks(title):
 			summary = show_summary
 			)
 		)
-	
+
 	oc.add(DirectoryObject(
 		key = Callback(ClearBookmarks),
 		title = "Clear Bookmarks",
@@ -154,13 +154,13 @@ def Bookmarks(title):
 		summary = "CAUTION! This will clear your entire bookmark list!"
 		)
 	)
-	
+
 	return oc
 
 ######################################################################################
 # Takes query and formats it in a way that ShowCategory can use to display results.
 
-@route(PREFIX + "/search")	
+@route(PREFIX + "/search")
 def Search(query):
 
 	search_category = "/toon/search?key=" + query.replace(' ', '+') + "&page="
@@ -169,9 +169,9 @@ def Search(query):
 ######################################################################################
 # Collects results from category and creates objects accordingly.
 
-@route(PREFIX + "/showcategory")	
+@route(PREFIX + "/showcategory")
 def ShowCategory(title, category, page_count, is_popular):
-	
+
 	oc = ObjectContainer(title1 = title)
 	page_count = int(page_count) + 1
 	page_data = HTML.ElementFromURL(BASE_URL + str(category) + str(page_count))
@@ -180,7 +180,7 @@ def ShowCategory(title, category, page_count, is_popular):
 		series_xpath = "//div[@class='series_list'][2]/ul/li"
 	else:
 		series_xpath = "//div[@class='series_list']/ul/li"
-	
+
 	for each in page_data.xpath(series_xpath):
 
 		show_url = each.xpath("./div/h3/a/@href")[0]
@@ -188,7 +188,7 @@ def ShowCategory(title, category, page_count, is_popular):
 		show_thumb = each.xpath("./div/a/img/@src")[0]
 		show_details = [x.strip() for x in each.xpath(".//div[@class='info_bar']/span/span/text()")]
 		show_summary = each.xpath("./div/div[@class='descr']/text()")[0].split("[")[0].strip() + "\n\n" + " ".join(show_details[0:2]) + "\n" + " ".join(show_details[2:4]) + "\n" + " ".join(show_details[4:6])
-		
+
 		oc.add(DirectoryObject(
 			key = Callback(PageEpisodes, show_title = show_title, show_url = show_url),
 			title = show_title,
@@ -196,18 +196,18 @@ def ShowCategory(title, category, page_count, is_popular):
 			summary = show_summary
 			)
 		)
-			
+
 	if len(oc) >= 25:
 		oc.add(NextPageObject(key = Callback(ShowCategory, title = title, category = category, page_count = page_count, is_popular = is_popular), title = "More...", thumb = R(ICON_NEXT)))
-	
+
 	if len(oc) < 1:
 		Log ("No shows found! Check xpath queries.")
-		return ObjectContainer(header="Error", message="Something has gone horribly wrong! Please let TehCrucible know, at the Plex forums.")  
-	
+		return ObjectContainer(header="Error", message="Something has gone horribly wrong! Please let TehCrucible know, at the Plex forums.")
+
 	return oc
 
 ######################################################################################
-# Checks for pagination on show_url and returns DirectoryObjects for each page	
+# Checks for pagination on show_url and returns DirectoryObjects for each page
 
 @route(PREFIX + "/pageepisodes")
 def PageEpisodes(show_title, show_url):
@@ -222,13 +222,13 @@ def PageEpisodes(show_title, show_url):
 			show_summary = last_page.xpath("//div[@id='series_details']/div[2]/div/text()")[0].strip()
 		except:
 			show_summary = last_page.xpath("//div[@id='series_details']/div/div/text()")[0].strip()
-			
-	#check show_url for pagination and return total number of pages		
+
+	#check show_url for pagination and return total number of pages
 	try:
 		total_pages = int(last_page.xpath("//ul[@class='pagination']/li//span[@class='button-content']/text()")[len(last_page.xpath("//ul[@class='pagination']/li//span[@class='button-content']/text()")) - 1])
 	except:
 		total_pages = 1
-		
+
 	page_count = 0
 	while page_count < total_pages:
 		page_url = show_url + "?page=" + str(total_pages - page_count)
@@ -240,14 +240,14 @@ def PageEpisodes(show_title, show_url):
 				)
 			)
 		page_count = page_count + 1
-		
+
 	oc.add(DirectoryObject(
 		key = Callback(AddBookmark, show_title = show_title, show_url = show_url),
 		title = "Add Bookmark",
 		summary = "You can add " + show_title + " to your Bookmarks list, to make it easier to find later.",
 		thumb = R(ICON_QUEUE)
 		)
-	)	
+	)
 
 	return oc
 
@@ -255,71 +255,71 @@ def PageEpisodes(show_title, show_url):
 # Returns a list of PopupDirectoryObjects for each episode
 
 @route(PREFIX + "/listepisodes")
-def ListEpisodes(page_url):	
-	
+def ListEpisodes(page_url):
+
 	page_data = HTML.ElementFromURL(page_url)
 	episode_list = page_data.xpath("//div[@id='videos']/ul/li")
-	
+
 	if len(episode_list) == 1:
 		ep_url = page_data.xpath("//div[@id='videos']/ul/li/a/@href")[0]
 		return GetParts(ep_url = ep_url)
 
 	oc = ObjectContainer()
-	
+
 	for each in reversed(page_data.xpath("//div[@id='videos']/ul/li")):
 		ep_title = each.xpath("./a/text()")[0]
 		ep_url = each.xpath("./a/@href")[0]
-		
+
 		oc.add(PopupDirectoryObject(
 			key = Callback(GetParts, ep_url = ep_url),
 			title = ep_title,
-			summary = "Watch " + ep_title + " from AnimeToon.tv",
+			summary = "Watch " + ep_title + " from AnimeToon",
 			thumb = R(ICON_COVER)
 			)
 		)
-	
-	return oc	
+
+	return oc
 
 ######################################################################################
 # Returns a list of VideoClipObjects for each part of an episode
 
 @route(PREFIX + "/getparts")
 def GetParts(ep_url):
-	
+
 	oc = ObjectContainer()
 	page_data = HTML.ElementFromURL(ep_url)
 	ep_title = page_data.xpath("//div[@id='top_block']/h1/text()")[0].strip()
-	
+
 	for each in page_data.xpath("//div[@class='vmargin'][1]/div[1]/ul[@class='part_list']/li/a"):
 		oc.add(VideoClipObject(
 			url = each.xpath("./@href")[0],
 			title = ep_title + " " + each.xpath("./text()")[0],
-			summary = "Watch " + ep_title + " from AnimeToon.tv"
+			summary = "Watch " + ep_title + " from AnimeToon"
 			)
 		)
-	
+
 	if len(oc) < 1:
 		oc.add(VideoClipObject(
 			url = ep_url,
 			title = ep_title,
-			summary = "Watch " + ep_title + " from AnimeToon.tv"
+			summary = "Watch " + ep_title + " from AnimeToon"
 			)
 		)
 	return oc
 
 ######################################################################################
 # Adds a show to the bookmarks list using the title as a key for the url
-	
+
 @route(PREFIX + "/addbookmark")
 def AddBookmark(show_title, show_url):
-	
+
 	Dict[show_title] = show_url
 	Dict.Save()
 	return ObjectContainer(header=show_title, message='This show has been added to your bookmarks.')
-	
+
 ######################################################################################
 # Clears the Dict that stores the bookmarks list
-	
+
 @route(PREFIX + "/clearbookmarks")
 def ClearBookmarks():
 

--- a/Contents/Services/ServiceInfo.plist
+++ b/Contents/Services/ServiceInfo.plist
@@ -10,7 +10,7 @@
 			<string>com.plexapp.plugins.animetoon</string>
 			<key>URLPatterns</key>
 			<array>
-				<string>http://www.animetoon.tv/.+</string>
+				<string>https?\:\/\/www\.animetoon\.(?:[^/]+\/)?\/.+</string>
 			</array>
 		</dict>
 	</dict>

--- a/Contents/Services/URL/AnimeToon/ServiceCode.pys
+++ b/Contents/Services/URL/AnimeToon/ServiceCode.pys
@@ -1,31 +1,35 @@
+#!/usr/bin/env python
 ######################################################################################
+import base64
 
-BASE_URL = 'http://www.animetoon.tv'
-RE_VIDEOFUN = Regex('http://s(.*)(?=".\s)')
-RE_PLAY44 = Regex("http://.*gateway.*(?=')")
-RE_THUMB = Regex('http://videofun.me/frames/(.*)(?=".\s)')
-RE_CHEESE = Regex('http://stream.*(?=")')
-RE_VIDZUR = Regex("http://.*videos.*(?=')")
-RE_VIDEO44 = Regex('http://.*dl.*(?=")')
-RE_BYZOO = Regex("http://beta.*(?=')")
-ICON_COVER = "icon-cover.png"
+SEARCH_STRINGS = [
+	Regex("https?:\/\/.+?googleusercontent.com\/.*(?=(?:\"|\'))"),
+	Regex("http.*videozoo\.me.*(?=(?:\"|\'))"),
+	Regex("http:\/\/videofun.me\/frames\/(.*)(?=\".\s)"),
+	Regex("http:\/\/stream.*(?=\")"),
+	Regex("http:\/\/.*videos.*(?=')"),
+	Regex("http:\/\/.*dl.*(?=\")"),
+	Regex("http:\/\/beta.*(?=')"),
+	Regex("http(s?):\/\/.*googlevideo.*(?=')"),
+	Regex("http:\/\/.*gateway.*(?=')"),
+	Regex("http:\/\/s(.*)(?=\".\s)")
+	]
 
 ######################################################################################
-# Loads thumbnail from videofun iframe if available.
-
 def MetadataObjectForURL(url):
-	
+	"""Loads thumbnail from videofun iframe if available."""
+
 	ep_data = HTML.ElementFromURL(url)
 	show_data = HTML.ElementFromURL(ep_data.xpath("//div[@id='slink']/span/span/a/@href")[0])
 	ep_title = ep_data.xpath("//div[@id='top_block']/h1/text()")[0].strip()
 	show_thumb = show_data.xpath("//img[@id='series_image']/@src")[0]
 	show_genres = show_data.xpath("//span[@class='red_box']/a/text()")
-	
+
 	try:
 		show_rating = float(show_data.xpath("//span[@id='rating_num']/text()")[0])
 	except:
 		show_rating = 0.00
-	
+
 	try:
 		show_summary = show_data.xpath("//div[@class='right_col']/div/div[2]/div/span[2]/text()")[0].strip()
 	except:
@@ -33,70 +37,36 @@ def MetadataObjectForURL(url):
 			show_summary = show_data.xpath("//div[@id='series_details']/div[2]/div/text()")[0].strip()
 		except:
 			show_summary = show_data.xpath("//div[@id='series_details']/div/div/text()")[0].strip()
-	
+
 	return MovieObject(
 		title = ep_title,
 		thumb = Resource.ContentsOfURLWithFallback(url = show_thumb, fallback='icon-cover.png'),
 		summary = show_summary,
 		genres = show_genres,
 		rating = show_rating,
-		source_title = "AnimeToon.tv"
+		source_title = "AnimeToon"
 		)
 
 ######################################################################################
-# All videos vary in codec and must be transcoded
-
 @deferred
 def MediaObjectsForURL(url):
-	
+	"""All videos vary in codec and must be transcoded"""
+
 	page_data = HTML.ElementFromURL(url)
-	each = page_data.xpath("//div[@id='streams']//iframe/@src")[0]
-	
-	if each.find("videofun") >= 0:
-		page_data = HTMLElementFromURL(each)
-		string_data = HTML.StringFromElement(page_data)
-		find_url = RE_VIDEOFUN.search(string_data).group()
-		url = String.Unquote(find_url, usePlus=False)
-		Log(url)
-		return [MediaObject(parts = [PartObject(key = url)])]
+	each = page_data.xpath("//div[@id='streams']//iframe/@src")
 
-	elif each.find("video44") >= 0:
-		page_data = HTML.ElementFromURL(each)
-		string_data = HTML.StringFromElement(page_data)
-		find_url = RE_VIDEO44.search(string_data).group()
-		url = String.Unquote(find_url, usePlus=False)
-		Log(url)
-		return [MediaObject(parts = [PartObject(key = url)])]
+	for s in each:
+		if not 'videozoo.me' in s:
+			page_data = HTML.ElementFromURL(s)
+			string_data = HTML.StringFromElement(page_data)
+			match = False
+			for regex in SEARCH_STRINGS:
+				match = regex.search(string_data)
+				if match:
+					url = String.Unquote(match.group(), usePlus=False)
+					if 'videozoo' in url:
+						url = base64.b64decode(url.split('url=')[1])
+					Log.Debug('PlayVideo URL = %s' %url)
+					return [MediaObject(parts = [PartObject(key = url)])]
 
-	elif each.find("cheesestream") >= 0:
-		page_data = HTML.ElementFromURL(each)
-		string_data = HTML.StringFromElement(page_data)
-		url = RE_CHEESE.search(string_data).group()
-		Log(url)
-		return [MediaObject(parts = [PartObject(key = url)])]
-	
-	elif each.find("vidzur") >= 0:
-		page_data = HTML.ElementFromURL(each)
-		string_data = HTML.StringFromElement(page_data)
-		find_url = RE_VIDZUR.search(string_data).group()
-		url = String.Unquote(find_url, usePlus=False)
-		Log(url)
-		return [MediaObject(parts = [PartObject(key = url)])]
-		
-	elif each.find("play44") >= 0:
-		page_data = HTML.ElementFromURL(each)
-		string_data = HTML.StringFromElement(page_data)
-		find_url = RE_PLAY44.search(string_data).group()
-		url = String.Unquote(find_url, usePlus=False)
-		Log(url)
-		return [MediaObject(parts = [PartObject(key = url)])] 
-		
-	elif each.find("byzoo") >= 0:
-		page_data = HTML.ElementFromURL(each)
-		string_data = HTML.StringFromElement(page_data)
-		find_url = RE_BYZOO.search(string_data).group()
-		url = String.Unquote(find_url, usePlus=False)
-		Log(url)
-		return [MediaObject(parts = [PartObject(key = url)])]
-
-	
+	raise Ex.MediaNotAvailable


### PR DESCRIPTION
Not sure if you're still supporting this channel, but I took the liberty of simplifying the service code and updating the base URL to the current site URL.

I realize this channel is not the most useful via the multi-part issue, but the multi-part videos could be placed in a SeasonObject creating a way to play one after the other.  I did not do that in this pull requests, just wanted to updated the channel to working status.  Might take time later to play with the multi-part SeasonObject stuff.

Cheers,
Twoure